### PR TITLE
Pluggable Verifiers

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Services\Verification\MasterVerifier;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 
@@ -38,7 +39,7 @@ class LoginController extends Controller
         $this->middleware('guest')->except('logout');
     }
 
-    public function validateLogin(Request $request)
+    /*public function validateLogin(Request $request)
     {
 
         $request->validate([
@@ -46,5 +47,10 @@ class LoginController extends Controller
             'password' => 'required|string',
             'g-recaptcha-response' => 'required|captcha'
         ]);
+    }*/
+
+    public function validateLogin(Request $request)
+    {
+        app(MasterVerifier::class)->verify($request->all());
     }
 }

--- a/app/Services/Verification/Contracts/VerificationContract.php
+++ b/app/Services/Verification/Contracts/VerificationContract.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace App\Services\Verification\Contracts;
+
+
+use Illuminate\Http\Request;
+
+interface VerificationContract
+{
+    /**
+     * Verifies the challenge over given data
+     *
+     * @param $data
+     */
+    public function verify($data): void ;
+
+}

--- a/app/Services/Verification/MasterVerifier.php
+++ b/app/Services/Verification/MasterVerifier.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace App\Services\Verification;
+
+
+class MasterVerifier
+{
+    /**
+     * Runner method to invoke the all-in-config/supplied verifiers
+     *
+     * @param $data - Data to be run through verifier(s)
+     * @param array $verifiers - List of verifiers for data verification
+     */
+    public function verify($data, $verifiers = []): void
+    {
+        // Circuit bypass for no verifiers
+        if ($verifiers == null)
+            return;
+
+        // If no verifiers supplied to method,
+        // Get verifiers from bindings defined in verifier config
+        if (empty($verifiers))
+            $verifiers = config('verifiers.bindings', []);
+
+        foreach ($verifiers as $verifier)
+            // Verify the data through every verifier
+            app($verifier)->verify($data);
+
+
+    }
+}

--- a/app/Services/Verification/Verifiers/GoogleRecaptchaVerifier.php
+++ b/app/Services/Verification/Verifiers/GoogleRecaptchaVerifier.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace App\Services\Verifiers;
+
+
+use App\Services\Verification\Contracts\VerificationContract;
+use Illuminate\Support\Facades\Validator;
+
+
+/**
+ * Google reCaptcha Verifier
+ *
+ * Class GoogleRecaptchaVerifier
+ * @package App\Services\Verifiers
+ */
+class GoogleRecaptchaVerifier implements VerificationContract
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function verify($data): void
+    {
+        if (!$this->shouldActivate())
+            return;
+
+        Validator::make($data, [
+            'g-recaptcha-response' => 'required|captcha'
+        ])->validate();
+
+    }
+
+    /**
+     * Activator for reCaptcha verifier
+     *
+     * @return bool
+     */
+    protected function shouldActivate(): bool
+    {
+        return boolval(config('captcha.enable', false));
+    }
+}

--- a/app/Services/Verification/Verifiers/WebAuthVerifier.php
+++ b/app/Services/Verification/Verifiers/WebAuthVerifier.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace App\Services\Verifiers;
+
+
+use App\Services\Verification\Contracts\VerificationContract;
+use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Web Authentication Verifier
+ *
+ * Class WebAuthVerifier
+ * @package App\Services\Verifiers
+ */
+class WebAuthVerifier implements VerificationContract
+{
+
+    use AuthenticatesUsers;
+
+    /**
+     * @inheritDoc
+     */
+    public function verify($data): void
+    {
+
+        Validator::make($data, [
+            $this->username() => 'required|string',
+            'password' => 'required|string',
+        ])->validate();
+
+    }
+}

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -6,4 +6,5 @@ return [
     'options' => [
         'timeout' => 30,
     ],
+    'enable' => env('ENABLE_CAPTCHA', false)
 ];

--- a/config/verifiers.php
+++ b/config/verifiers.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'bindings' => [
+        'webauth' => \App\Services\Verifiers\WebAuthVerifier::class,
+        'captcha' => \App\Services\Verifiers\GoogleRecaptchaVerifier::class
+    ]
+];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -38,13 +38,23 @@
                             </div>
                         </div>
 
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right"></label>
+                        @if(config('captcha.enable', false))
 
-                            <div class="col-md-6">
-                                {!! NoCaptcha::display() !!}
+                            <div class="form-group row">
+                                <div class="col-md-6 offset-md-4">
+                                    @error('g-recaptcha-response')
+                                    <span class="alert alert-error small alert-dismissible fade show">
+                                        <strong>{{ $message }}</strong>
+                                        <button type="button" class="close small" data-dismiss="alert" aria-label="Close">
+                                            <span aria-hidden="true">&times;</span>
+                                        </button>
+                                    </span>
+                                    @enderror
+                                    {!! NoCaptcha::display() !!}
+                                </div>
                             </div>
-                        </div>
+                        @endif
+
 
                         <div class="form-group row">
                             <div class="col-md-6 offset-md-4">
@@ -76,5 +86,7 @@
         </div>
     </div>
 </div>
-{!! NoCaptcha::renderJs() !!}
+@if(config('captcha.enable', false))
+    {!! NoCaptcha::renderJs() !!}
+@endif
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -75,12 +75,22 @@
                             </div>
                         </div>
 
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right"></label>
-                            <div class="col-md-6">
-                                {!! NoCaptcha::display() !!}
+                        @if(config('captcha.enable', false))
+
+                            <div class="form-group row">
+                                <div class="col-md-6 offset-md-4">
+                                    @error('g-recaptcha-response')
+                                    <span class="alert alert-error small alert-dismissible fade show">
+                                        <strong>{{ $message }}</strong>
+                                        <button type="button" class="close small" data-dismiss="alert" aria-label="Close">
+                                            <span aria-hidden="true">&times;</span>
+                                        </button>
+                                    </span>
+                                    @enderror
+                                    {!! NoCaptcha::display() !!}
+                                </div>
                             </div>
-                        </div>
+                        @endif
 
                         <div class="form-group row mb-0">
                             <div class="col-md-6 offset-md-4">
@@ -95,5 +105,7 @@
         </div>
     </div>
 </div>
-{!! NoCaptcha::renderJs() !!}
+@if(config('captcha.enable', false))
+    {!! NoCaptcha::renderJs() !!}
+@endif
 @endsection


### PR DESCRIPTION
Fixed #20 

Google reCaptcha like add-on Verifiers are made _pluggable_ through central `VerificationContract` and `MasterVerifier(runner)`

Web auth verifier (login validator) is made pluggable to define extension-ability to existing validators.

Additionally refactored invalid namespace import of AssignRoleUserUsecaseInterface in RegistrationController.